### PR TITLE
Require LV2 >= 1.10.0

### DIFF
--- a/wscript
+++ b/wscript
@@ -64,7 +64,7 @@ def configure(conf):
     if not conf.options.disable_tools: conf.check_boost()
 
     # Check for required packages
-    conf.check_lv2 ("1.8.0")
+    conf.check_lv2 ("1.10.0")
 
     # UI Configuration
     autowaf.check_pkg(conf, "gtkmm-2.4", uselib_store="gtkmm", \


### PR DESCRIPTION
Required function lv2_atom_forge_key() was introduced in LV2 == 1.10.0