### PR TITLE
Add GTK3 support

### DIFF
--- a/lvtk-gtk3ui.pc.in
+++ b/lvtk-gtk3ui.pc.in
@@ -1,0 +1,11 @@
+prefix=@PREFIX@
+exec_prefix=@EXEC_PREFIX@
+libdir=@LIBDIR@
+includedir=@INCLUDEDIR@
+
+Name: lvtk-gtk3ui
+Version: @VERSION@
+Description: LV2 Toolkit Gtk3UI 
+Requires: @LVTK_PKG_DEPS@
+Libs: -L${libdir} -l@THELIB@
+Cflags: -Wl,-z,nodelete -I${includedir}/lvtk-@LVTK_MAJOR_VERSION@

--- a/lvtk/gtk3ui.hpp
+++ b/lvtk/gtk3ui.hpp
@@ -1,0 +1,126 @@
+/*
+
+    gtkui.hpp - Wrapper library to make it easier to write LV2 Gtk3UIs in C++
+
+    Copyright (C) 2006-2008 Lars Luthman <lars.luthman@gmail.com>
+    Modified by Dave Robillard, 2008 (URI map mixin)
+    Modified by Michael Fisher, 2012 (LV2 rev3)
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor,
+    Boston, MA  02110-1301  USA
+
+ */
+
+#ifndef LVTK_GTK3UI_HPP
+#define LVTK_GTK3UI_HPP
+
+#include <gtkmm.h>
+#include <lvtk/ui.hpp>
+
+
+namespace lvtk {
+
+
+    /** The Gtk3UI Mixin.
+        @headerfile lvtk/gtkui.hpp
+        @ingroup guimixins
+        @ingroup toolkitmixins
+        @see The internal struct I for API details.
+     */
+    template <bool Required = true>
+    struct Gtk3UI
+    {
+        /** @memberof Gtk3UI */
+        template <class Derived>
+        struct I : Extension<Required>
+        {
+            I() : p_container(NULL)
+            {
+                /* Call before anything else. Prevents glib warnings */
+                Gtk::Main::init_gtkmm_internals();
+
+                p_container = Gtk::manage (new Gtk::Box(Gtk::ORIENTATION_VERTICAL));
+            }
+
+            ~I()
+            {
+                /** Container is managed, so don't delete it */
+            }
+
+            /** @skip */
+            static void
+            map_feature_handlers (FeatureHandlerMap& hmap)
+            {
+                /** Not required or implemented */
+            }
+
+
+            /**
+               Sanity check the Mixin
+               @return true if the container was created.
+             */
+            bool
+            check_ok()
+            {
+                return (p_container != NULL);
+            }
+
+        protected:
+
+            /**
+               Get the underlying Box container Object
+               @return Underlying Gtk:HBox
+             */
+            Gtk::Box& container()
+            {
+                return *p_container;
+            }
+
+            /**
+               Add a main widget
+
+               @param widget Gtkmm main UI widget
+               @return void
+               @remarks You can also use the container() method to acquire the
+               underlying Gtk::Box. Do this if you want to add widgets using
+               pack_start and pack_end.
+             */
+            void add (Gtk::Widget& widget)
+            {
+                p_container->pack_start (widget);
+            }
+
+            /**
+               Get the Gtk widget as an LV2UI_Widget
+               @return The LV2UI_Widget pointer
+             */
+            LV2UI_Widget*
+            widget()
+            {
+                return widget_cast (p_container->gobj());
+            }
+
+        private:
+            /** The container object that harbors the main widget */
+            Gtk::Box *p_container;
+
+        };
+    };
+
+
+} /* namespace lvtk */
+
+
+#endif /* LVTK_GTK3UI_HPP */

--- a/wscript
+++ b/wscript
@@ -61,8 +61,11 @@ def configure (conf):
 
     conf.check_inline()
     conf.check_lv2 ("1.10.0")
+
     autowaf.check_pkg (conf, "gtkmm-2.4", uselib_store="gtkmm", \
                              atleast_version="2.20.0", mandatory=False)
+    autowaf.check_pkg (conf, "gtkmm-3.0", uselib_store="gtkmm3", \
+                             atleast_version="3.20.0", mandatory=False)
 
     # Setup the Environment
     conf.env.EXAMPLES_DISABLED  = conf.options.disable_examples or len(conf.env.TTL2C) == 0
@@ -121,6 +124,12 @@ def build (bld):
                 'VERSION'             : LVTK_VERSION,
                 'THELIB'              : LIB_LVTK_UI,
                 'LVTK_PKG_DEPS'       : 'lv2 gtkmm-2.4'})
+        if bld.env.LIB_gtkmm3:
+            autowaf.build_pc(bld, 'LVTK-GTK3UI', LVTK_VERSION, pcvers, [],
+                {'LVTK_MAJOR_VERSION' : LVTK_MAJOR_VERSION,
+                'VERSION'             : LVTK_VERSION,
+                'THELIB'              : LIB_LVTK_UI,
+                'LVTK_PKG_DEPS'       : 'lv2 gtkmm-3.0'})
 
     bld.add_group()
 


### PR DESCRIPTION
I have been experimenting porting some GTK2 plugins to GTK3. This PR should make it possible to build against a "lvtk-gtk3ui-2" pkgconfig target without interfering with any GTK2 plugins. The gtk3ui.hpp header is new because VBox is deprecated in GTK3. I am open to suggestions if there are any better ways to structure this.