### PR TITLE
Changed the include directives to the lv2 SDK

### DIFF
--- a/lvtk/dynmanifest.hpp
+++ b/lvtk/dynmanifest.hpp
@@ -46,7 +46,7 @@
 
 #pragma once
 
-#include <lv2/lv2plug.in/ns/ext/dynmanifest/dynmanifest.h>
+#include <lv2/dynmanifest/dynmanifest.h>
 #include <sstream>
 #include <cstdio>
 

--- a/lvtk/ext/atom.hpp
+++ b/lvtk/ext/atom.hpp
@@ -23,9 +23,9 @@
 #include <iostream>
 #include <string>
 
-#include <lv2/lv2plug.in/ns/ext/atom/atom.h>
-#include <lv2/lv2plug.in/ns/ext/atom/forge.h>
-#include <lv2/lv2plug.in/ns/ext/atom/util.h>
+#include <lv2/atom/atom.h>
+#include <lv2/atom/forge.h>
+#include <lv2/atom/util.h>
 
 namespace lvtk {
 /* @{ */

--- a/lvtk/ext/bufsize.hpp
+++ b/lvtk/ext/bufsize.hpp
@@ -43,7 +43,7 @@
 
 #pragma once
 
-#include <lv2/lv2plug.in/ns/ext/buf-size/buf-size.h>
+#include <lv2/buf-size/buf-size.h>
 #include <lvtk/ext/options.hpp>
 #include <lvtk/ext/urid.hpp>
 #include <lvtk/optional.hpp>

--- a/lvtk/ext/data_access.hpp
+++ b/lvtk/ext/data_access.hpp
@@ -20,7 +20,7 @@
 
 #pragma once
 
-#include <lv2/lv2plug.in/ns/ext/data-access/data-access.h>
+#include <lv2/data-access/data-access.h>
 #include <lvtk/ext/extension.hpp>
 
 namespace lvtk {

--- a/lvtk/ext/instance_access.hpp
+++ b/lvtk/ext/instance_access.hpp
@@ -20,7 +20,7 @@
 
 #pragma once
 
-#include <lv2/lv2plug.in/ns/ext/instance-access/instance-access.h>
+#include <lv2/instance-access/instance-access.h>
 #include <lvtk/ext/extension.hpp>
 
 namespace lvtk {

--- a/lvtk/ext/log.hpp
+++ b/lvtk/ext/log.hpp
@@ -17,7 +17,7 @@
 #pragma once
 
 #include <lvtk/ext/extension.hpp>
-#include <lv2/lv2plug.in/ns/ext/log/log.h>
+#include <lv2/log/log.h>
 
 /** @defgroup log Log
     Logging support

--- a/lvtk/ext/options.hpp
+++ b/lvtk/ext/options.hpp
@@ -20,7 +20,7 @@
 
 #pragma once
 
-#include <lv2/lv2plug.in/ns/ext/options/options.h>
+#include <lv2/options/options.h>
 #include <lvtk/ext/extension.hpp>
 
 namespace lvtk {

--- a/lvtk/ext/resize_port.hpp
+++ b/lvtk/ext/resize_port.hpp
@@ -20,7 +20,7 @@
 
 #pragma once
 
-#include <lv2/lv2plug.in/ns/ext/resize-port/resize-port.h>
+#include <lv2/resize-port/resize-port.h>
 #include <lvtk/ext/extension.hpp>
 
 namespace lvtk {

--- a/lvtk/ext/state.hpp
+++ b/lvtk/ext/state.hpp
@@ -20,7 +20,7 @@
 
 #pragma once
 
-#include <lv2/lv2plug.in/ns/ext/state/state.h>
+#include <lv2/state/state.h>
 #include <lvtk/ext/extension.hpp>
 
 namespace lvtk {

--- a/lvtk/ext/ui/idle.hpp
+++ b/lvtk/ext/ui/idle.hpp
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#include <lv2/lv2plug.in/ns/extensions/ui/ui.h>
+#include <lv2/ui/ui.h>
 #include <lvtk/ext/extension.hpp>
 
 namespace lvtk {

--- a/lvtk/ext/ui/parent.hpp
+++ b/lvtk/ext/ui/parent.hpp
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#include <lv2/lv2plug.in/ns/extensions/ui/ui.h>
+#include <lv2/ui/ui.h>
 #include <lvtk/ext/extension.hpp>
 
 namespace lvtk {

--- a/lvtk/ext/ui/port_map.hpp
+++ b/lvtk/ext/ui/port_map.hpp
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#include <lv2/lv2plug.in/ns/extensions/ui/ui.h>
+#include <lv2/ui/ui.h>
 #include <lvtk/ext/extension.hpp>
 
 namespace lvtk {

--- a/lvtk/ext/ui/port_subscribe.hpp
+++ b/lvtk/ext/ui/port_subscribe.hpp
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#include <lv2/lv2plug.in/ns/extensions/ui/ui.h>
+#include <lv2/ui/ui.h>
 #include <lvtk/ext/extension.hpp>
 
 namespace lvtk {

--- a/lvtk/ext/ui/resize.hpp
+++ b/lvtk/ext/ui/resize.hpp
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#include <lv2/lv2plug.in/ns/extensions/ui/ui.h>
+#include <lv2/ui/ui.h>
 #include <lvtk/ext/extension.hpp>
 
 namespace lvtk {

--- a/lvtk/ext/ui/show.hpp
+++ b/lvtk/ext/ui/show.hpp
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#include <lv2/lv2plug.in/ns/extensions/ui/ui.h>
+#include <lv2/ui/ui.h>
 #include <lvtk/ext/ui/idle.hpp>
 
 namespace lvtk {

--- a/lvtk/ext/ui/touch.hpp
+++ b/lvtk/ext/ui/touch.hpp
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#include <lv2/lv2plug.in/ns/extensions/ui/ui.h>
+#include <lv2/ui/ui.h>
 #include <lvtk/ext/extension.hpp>
 
 namespace lvtk {

--- a/lvtk/ext/urid.hpp
+++ b/lvtk/ext/urid.hpp
@@ -20,7 +20,7 @@
 
 #pragma once
 
-#include <lv2/lv2plug.in/ns/ext/urid/urid.h>
+#include <lv2/urid/urid.h>
 #include <lvtk/ext/extension.hpp>
 
 namespace lvtk {

--- a/lvtk/ext/worker.hpp
+++ b/lvtk/ext/worker.hpp
@@ -52,7 +52,7 @@
 
 #pragma once
 
-#include <lv2/lv2plug.in/ns/ext/worker/worker.h>
+#include <lv2/worker/worker.h>
 #include <lvtk/ext/extension.hpp>
 
 namespace lvtk {

--- a/lvtk/lvtk.hpp
+++ b/lvtk/lvtk.hpp
@@ -45,8 +45,8 @@
 #include <string>
 #include <vector>
 
-#include <lv2/lv2plug.in/ns/lv2core/lv2.h>
-#include <lv2/lv2plug.in/ns/ext/urid/urid.h>
+#include <lv2/core/lv2.h>
+#include <lv2/urid/urid.h>
 
 namespace lvtk {
 /** @defgroup lvtk Core

--- a/lvtk/plugin.hpp
+++ b/lvtk/plugin.hpp
@@ -90,7 +90,7 @@ public:
 private:
     inline void register_plugin (const char* uri) {
         LV2_Descriptor desc;
-        desc.URI            = strdup (uri);
+        desc.URI            = _strdup (uri);
         desc.instantiate    = P::_instantiate;
         desc.activate       = P::_activate;
         desc.connect_port   = P::_connect_port;

--- a/lvtk/ui.hpp
+++ b/lvtk/ui.hpp
@@ -26,7 +26,7 @@
 #pragma once
 
 #include <memory>
-#include <lv2/lv2plug.in/ns/extensions/ui/ui.h>
+#include <lv2/ui/ui.h>
 #include <lvtk/lvtk.hpp>
 
 namespace lvtk {

--- a/lvtk/uri_directory.hpp
+++ b/lvtk/uri_directory.hpp
@@ -19,7 +19,7 @@
 #include <unordered_map>
 #include <string>
 #include <lv2/lv2plug.in/ns/lv2core/lv2.h>
-#include <lv2/lv2plug.in/ns/ext/urid/urid.h>
+#include <lv2/urid/urid.h>
 
 namespace lvtk {
 

--- a/lvtk/uri_directory.hpp
+++ b/lvtk/uri_directory.hpp
@@ -18,7 +18,7 @@
 
 #include <unordered_map>
 #include <string>
-#include <lv2/lv2plug.in/ns/lv2core/lv2.h>
+#include <lv2/core/lv2.h>
 #include <lv2/urid/urid.h>
 
 namespace lvtk {


### PR DESCRIPTION
Include directives to the lv2 SDK changed from the old "universal URI-based style" to the "newer simple core style". See README.md at https://gitlab.com/lv2/lv2, in the paragraph "Header Installation":

«Projects are encouraged to migrate to the latter style»

The following note is not quite clear to me: «though note that this style of include path may only be used by official LV2 specifications». Anyway, after downloading the lv2 SDK I could not use the old-style includes while developing on Windows using VisualStudio. Probably the new style is more compatible across development platforms.