### PR TITLE
Add missing OpenGL dependency

### DIFF
--- a/meson/deps/meson.build
+++ b/meson/deps/meson.build
@@ -67,6 +67,10 @@ pugl_gl_dep = dependency ('pugl-gl-0',
     required : true
 )
 
+### OpenGL
+
+opengl_dep = dependency ('GL', include_type : 'system')
+
 ### Lilv & Suil
 lilv_dep = dependency ('lilv-0', required : false)
 suil_dep = dependency ('suil-0', required : false)

--- a/src/meson.build
+++ b/src/meson.build
@@ -47,7 +47,7 @@ lvtk_gl_c_args = ['-DLVTK_BUILD']
 lvtk_gl_cpp_args = lvtk_gl_c_args
 subdir ('nanovg')
 
-lvtk_opengl_deps = [ lvtk_widgets_dep, pugl_gl_dep, dl_dep ]
+lvtk_opengl_deps = [ lvtk_widgets_dep, pugl_gl_dep, dl_dep, opengl_dep ]
 
 liblvtk_opengl = library ('lvtk-opengl-@0@'.format (lvtk_abi_version),
     lvtk_gl_sources,


### PR DESCRIPTION
Fixes FTBFS at least on Manjaro.  Since the code here directly uses OpenGL (via nanovg), it needs to have a dependency on OpenGL itself, pugl-gl doesn't export this dependency.